### PR TITLE
Use pycodestyle in place of pep8

### DIFF
--- a/ament_pep8/configuration/ament_pep8.ini
+++ b/ament_pep8/configuration/ament_pep8.ini
@@ -1,3 +1,3 @@
-[pep8]
+[pycodestyle]
 ignore = ''
 max-line-length = 99

--- a/ament_pep8/main.py
+++ b/ament_pep8/main.py
@@ -20,7 +20,7 @@ import sys
 from xml.sax.saxutils import escape
 from xml.sax.saxutils import quoteattr
 
-import pep8
+import pycodestyle
 
 
 def main(argv=sys.argv[1:]):
@@ -177,14 +177,14 @@ def get_xunit_content(report, testname):
     return xml
 
 
-class CustomStyleGuide(pep8.StyleGuide):
+class CustomStyleGuide(pycodestyle.StyleGuide):
 
     def input_file(self, filename, **kwargs):
         self.options.reporter.files.append(filename)
         return super(CustomStyleGuide, self).input_file(filename, **kwargs)
 
 
-class CustomReport(pep8.StandardReport):
+class CustomReport(pycodestyle.StandardReport):
 
     errors = []
     files = []

--- a/package.xml
+++ b/package.xml
@@ -10,7 +10,7 @@
   <maintainer email="dthomas@osrfoundation.org">Dirk Thomas</maintainer>
   <license>Apache License 2.0</license>
 
-  <exec_depend>python3-pep8</exec_depend>
+  <exec_depend>python3-pycodestyle</exec_depend>
 
   <export>
     <build_type>ament_python</build_type>

--- a/rpm/template.spec.em
+++ b/rpm/template.spec.em
@@ -15,6 +15,7 @@ License:        @(License)
 Source0:        %{name}-%{version}.tar.gz
 @[if NoArch]@\nBuildArch:      noarch@\n@[end if]@
 
+Requires:       python%{python3_pkgversion}-pycodestyle
 @[for p in Depends]Requires:       @p@\n@[end for]@
 @[for p in sorted(BuildDepends + ['python%{python3_pkgversion}-devel'])]BuildRequires:  @p@\n@[end for]@
 @[for p in Conflicts]Conflicts:      @p@\n@[end for]@


### PR DESCRIPTION
In Foxy and newer, this package has been replaced with `ament_pycodestyle`. Since the Python API for pep8 is compatible with pycodestyle, we can switch to pycodestyle under-the-hood so that downstream packages don't need to be updated.

If downstream packages provide their own configuration, they will get a deprecation warning about switching the section header to `pycodestyle`, but I'm not aware of any packages which do this.

**NOTE**: If this PR is squash-merged, be sure to drop the PR number from the end of the commit message, or every time this patch is re-applied by Bloom, it will be back-linked from this PR.