### PR TITLE
Skip unavailable packages for RHEL

### DIFF
--- a/tracks.yaml
+++ b/tracks.yaml
@@ -208,7 +208,10 @@ tracks:
     - git-bloom-generate -y rosdebian --prefix release/:{ros_distro} :{ros_distro}
       -i :{release_inc} --os-name debian --os-not-required
     - git-bloom-generate -y rosrpm --prefix release/:{ros_distro} :{ros_distro} -i
-      :{release_inc}
+      :{release_inc} --os-name fedora
+    - git-bloom-generate -y rosrpm --prefix release/:{ros_distro} :{ros_distro} -i
+      :{release_inc} --os-name rhel
+      --skip-keys clang-tidy pydocstyle python3-flake8 python3-mypy python3-pytest-mock
     devel_branch: master
     last_version: 0.10.0
     name: ament_lint


### PR DESCRIPTION
These rosdep keys are unsatisfied for RHEL 7, which is the only RPM platform we're targeting. They'll need to be manually installed via pip.

Fortunately, all of them are needed only for testing, so their absence shouldn't block us from building any downstream packages.

This PR should be held until ros-infrastructure/bloom#604 is merged, since the action list will be changed at that time.